### PR TITLE
only define print line2 secret if SECRET_MODE is enabled

### DIFF
--- a/app/common/view_x.c
+++ b/app/common/view_x.c
@@ -279,11 +279,12 @@ void h_secret_click() {
 
 void view_idle_show_impl(__Z_UNUSED uint8_t item_idx, char *statusString) {
     if (statusString == NULL ) {
+        snprintf(viewdata.key, MAX_CHARS_PER_KEY_LINE, "%s", MENU_MAIN_APP_LINE2);
+#ifdef APP_SECRET_MODE_ENABLED
         if (app_mode_secret()) {
             snprintf(viewdata.key, MAX_CHARS_PER_KEY_LINE, "%s", MENU_MAIN_APP_LINE2_SECRET);
-        } else {
-            snprintf(viewdata.key, MAX_CHARS_PER_KEY_LINE, "%s", MENU_MAIN_APP_LINE2);
         }
+#endif
     } else {
         snprintf(viewdata.key, MAX_CHARS_PER_KEY_LINE, "%s", statusString);
     }

--- a/include/zxversion.h
+++ b/include/zxversion.h
@@ -17,4 +17,4 @@
 
 #define ZXLIB_MAJOR     13
 #define ZXLIB_MINOR     0
-#define ZXLIB_PATCH     0
+#define ZXLIB_PATCH     1


### PR DESCRIPTION
This allows apps to not have defined MENU_MAIN_APP_LINE2_SECRET.
Follows the same structure defined in `view_s.c`.
I tested it with nanosp and doesn't change anything at user end 👌🏻 

<!-- ClickUpRef: 2kaxj83 -->
:link: [zboto Link](https://app.clickup.com/t/2kaxj83)