### PR TITLE
fix template.sh to allow spaces in APPNAME

### DIFF
--- a/include/zxversion.h
+++ b/include/zxversion.h
@@ -15,6 +15,6 @@
 ********************************************************************************/
 #pragma once
 
-#define ZXLIB_MAJOR     13
+#define ZXLIB_MAJOR     14
 #define ZXLIB_MINOR     0
-#define ZXLIB_PATCH     1
+#define ZXLIB_PATCH     0

--- a/scripts/template.sh
+++ b/scripts/template.sh
@@ -44,10 +44,10 @@ echo -e "${APPHEX}" > ${BIN_HEX_FILE}
 case "$1" in
   'load')
   cd "$TMP_HEX_DIR" || exit
-  python3 -m ledgerblue.loadApp --appFlags 0x200 --delete ${LOAD_PARAMS} --path ${APPPATH} --path "44'/1'"
+  python3 -m ledgerblue.loadApp "${LOAD_PARAMS[@]}"
   ;;
   'delete')
-  python3 -m ledgerblue.deleteApp ${DELETE_PARAMS}
+  python3 -m ledgerblue.deleteApp "${DELETE_PARAMS[@]}"
   ;;
   'version')
   echo "v${APPVERSION}"


### PR DESCRIPTION
BREAKING CHANGES: $LOAD_PARAMS and $DELETE_PARAMS now need to be an
array instead of regular variables

<!-- ClickUpRef: 2m7g4qk -->
:link: [zboto Link](https://app.clickup.com/t/2m7g4qk)