### PR TITLE
Bech32m

### DIFF
--- a/include/bech32.h
+++ b/include/bech32.h
@@ -20,6 +20,7 @@ extern "C" {
 #endif
 
 #include "zxerror.h"
+#include "segwit_addr.h"
 
 #define MAX_INPUT_SIZE 64
 
@@ -32,7 +33,8 @@ zxerr_t bech32EncodeFromBytes(char *out,
                               const char *hrp,
                               const uint8_t *in,
                               size_t in_len,
-                              uint8_t pad);
+                              uint8_t pad,
+                              bech32_encoding enc);
 
 #ifdef __cplusplus
 }

--- a/include/segwit_addr.h
+++ b/include/segwit_addr.h
@@ -64,23 +64,36 @@ int segwit_addr_decode(
         const char *addr
 );
 
-/** Encode a Bech32 string
+/** Supported encodings. */
+typedef enum {
+    BECH32_ENCODING_NONE,
+    BECH32_ENCODING_BECH32,
+    BECH32_ENCODING_BECH32M
+} bech32_encoding;
+
+#define BECH32M_CONST   0x2bc830a3
+#define BECH32_CONST    1
+
+/** Encode a Bech32 or Bech32m string
  *
  *  Out: output:  Pointer to a buffer of size strlen(hrp) + data_len + 8 that
  *                will be updated to contain the null-terminated Bech32 string.
  *  In: hrp :     Pointer to the null-terminated human readable part.
  *      data :    Pointer to an array of 5-bit values.
  *      data_len: Length of the data array.
+ *      enc:      Which encoding to use (BECH32_ENCODING_BECH32{,M}).
+
  *  Returns 1 if successful.
  */
 int bech32_encode(
         char *output,
         const char *hrp,
         const uint8_t *data,
-        size_t data_len
+        size_t data_len,
+        bech32_encoding enc
 );
 
-/** Decode a Bech32 string
+/** Decode a Bech32 or Bech32m string
  *
  *  Out: hrp:      Pointer to a buffer of size strlen(input) - 6. Will be
  *                 updated to contain the null-terminated human readable part.
@@ -89,9 +102,11 @@ int bech32_encode(
  *       data_len: Pointer to a size_t that will be updated to be the number
  *                 of entries in data.
  *  In: input:     Pointer to a null-terminated Bech32 string.
- *  Returns 1 if successful.
+ *  Returns BECH32_ENCODING_BECH32{,M} to indicate decoding was successful
+ *  with the specified encoding standard. BECH32_ENCODING_NONE is returned if
+ *  decoding failed.
  */
-int bech32_decode(
+bech32_encoding bech32_decode(
         char *hrp,
         uint8_t *data,
         size_t *data_len,

--- a/include/zxversion.h
+++ b/include/zxversion.h
@@ -15,6 +15,6 @@
 ********************************************************************************/
 #pragma once
 
-#define ZXLIB_MAJOR     14
-#define ZXLIB_MINOR     1
-#define ZXLIB_PATCH     8
+#define ZXLIB_MAJOR     15
+#define ZXLIB_MINOR     0
+#define ZXLIB_PATCH     0

--- a/src/bech32.c
+++ b/src/bech32.c
@@ -26,7 +26,8 @@ zxerr_t bech32EncodeFromBytes(char *out,
                               const char *hrp,
                               const uint8_t *in,
                               size_t in_len,
-                              uint8_t pad) {
+                              uint8_t pad,
+                              bech32_encoding enc) {
     MEMZERO(out, out_len);
 
     if (in_len > MAX_INPUT_SIZE) {
@@ -49,7 +50,7 @@ zxerr_t bech32EncodeFromBytes(char *out,
         return zxerr_out_of_bounds;
     }
 
-    int err = bech32_encode(out, hrp, tmp_data, tmp_size);
+    int err = bech32_encode(out, hrp, tmp_data, tmp_size, enc);
     if (err == 0) {
         return zxerr_encoding_failed;
     }

--- a/src/segwit_addr.c
+++ b/src/segwit_addr.c
@@ -34,6 +34,12 @@ uint32_t bech32_polymod_step(uint32_t pre) {
            (-((b >> 4u) & 1u) & 0x2a1462b3UL);
 }
 
+static uint32_t bech32_final_constant(bech32_encoding enc) {
+    if (enc == BECH32_ENCODING_BECH32) return 1;
+    if (enc == BECH32_ENCODING_BECH32M) return 0x2bc830a3;
+    return 0;
+}
+
 static const char* charset = "qpzry9x8gf2tvdw0s3jn54khce6mua7l";
 
 static const int8_t charset_rev[128] = {
@@ -47,7 +53,7 @@ static const int8_t charset_rev[128] = {
         1,  0,  3, 16, 11, 28, 12, 14,  6,  4,  2, -1, -1, -1, -1, -1
 };
 
-int bech32_encode(char *output, const char *hrp, const uint8_t *data, size_t data_len) {
+int bech32_encode(char *output, const char *hrp, const uint8_t *data, size_t data_len, bech32_encoding enc) {
     uint32_t chk = 1;
     size_t i = 0;
     while (hrp[i] != 0) {
@@ -75,7 +81,7 @@ int bech32_encode(char *output, const char *hrp, const uint8_t *data, size_t dat
     for (i = 0; i < 6; ++i) {
         chk = bech32_polymod_step(chk);
     }
-    chk ^= 1;
+    chk ^= bech32_final_constant(enc);
     for (i = 0; i < 6; ++i) {
         *(output++) = charset[(chk >> ((5u - i) * 5u)) & 0x1fu];
     }
@@ -83,7 +89,7 @@ int bech32_encode(char *output, const char *hrp, const uint8_t *data, size_t dat
     return 1;
 }
 
-int bech32_decode(char* hrp, uint8_t *data, size_t *data_len, const char *input) {
+bech32_encoding bech32_decode(char* hrp, uint8_t *data, size_t *data_len, const char *input) {
     uint32_t chk = 1;
     size_t i;
     size_t input_len = strlen(input);
@@ -135,9 +141,15 @@ int bech32_decode(char* hrp, uint8_t *data, size_t *data_len, const char *input)
         ++i;
     }
     if (have_lower && have_upper) {
-        return 0;
+        return BECH32_ENCODING_NONE;
     }
-    return chk == 1;
+    if (chk == bech32_final_constant(BECH32_ENCODING_BECH32)) {
+        return BECH32_ENCODING_BECH32;
+    } else if (chk == bech32_final_constant(BECH32_ENCODING_BECH32M)) {
+        return BECH32_ENCODING_BECH32M;
+    } else {
+        return BECH32_ENCODING_NONE;
+    }
 }
 
 int convert_bits(uint8_t* out, size_t* outlen, int outBits, const uint8_t* in, size_t inLen, int inBits, int pad) {
@@ -165,23 +177,28 @@ int convert_bits(uint8_t* out, size_t* outlen, int outBits, const uint8_t* in, s
 int segwit_addr_encode(char *output, const char *hrp, int witver, const uint8_t *witprog, size_t witprog_len) {
     uint8_t data[65];
     size_t datalen = 0;
+    bech32_encoding enc = BECH32_ENCODING_BECH32;
     if (witver > 16) return 0;
     if (witver == 0 && witprog_len != 20 && witprog_len != 32) return 0;
     if (witprog_len < 2 || witprog_len > 40) return 0;
+    if (witver > 0) enc = BECH32_ENCODING_BECH32M;
     data[0] = witver;
     convert_bits(data + 1, &datalen, 5, witprog, witprog_len, 8, 1);
     ++datalen;
-    return bech32_encode(output, hrp, data, datalen);
+    return bech32_encode(output, hrp, data, datalen, enc);
 }
 
 int segwit_addr_decode(int* witver, uint8_t* witdata, size_t* witdata_len, const char* hrp, const char* addr) {
     uint8_t data[84];
     char hrp_actual[84];
     size_t data_len;
-    if (!bech32_decode(hrp_actual, data, &data_len, addr)) return 0;
+    bech32_encoding enc = bech32_decode(hrp_actual, data, &data_len, addr);
+    if (enc == BECH32_ENCODING_NONE) return 0;
     if (data_len == 0 || data_len > 65) return 0;
     if (strncmp(hrp, hrp_actual, 84) != 0) return 0;
     if (data[0] > 16) return 0;
+    if (data[0] == 0 && enc != BECH32_ENCODING_BECH32) return 0;
+    if (data[0] > 0 && enc != BECH32_ENCODING_BECH32M) return 0;
     *witdata_len = 0;
     if (!convert_bits(witdata, witdata_len, 8, data + 1, data_len - 1, 5, 0)) return 0;
     if (*witdata_len < 2 || *witdata_len > 40) return 0;

--- a/tests/bech32.cpp
+++ b/tests/bech32.cpp
@@ -26,23 +26,23 @@ namespace {
         uint8_t data1[] = {1, 3, 5};
         uint8_t data2[] = {1, 3, 5, 7, 9, 11, 13};
 
-        auto err = bech32EncodeFromBytes(addr_out, sizeof(addr_out), hrp, data1, sizeof(data1), 0);
+        auto err = bech32EncodeFromBytes(addr_out, sizeof(addr_out), hrp, data1, sizeof(data1), 0, BECH32_ENCODING_BECH32);
         ASSERT_EQ(err, zxerr_ok);
         std::cout << addr_out << std::endl;
         ASSERT_STREQ("zx1qypse825ac", addr_out);
 
-        err = bech32EncodeFromBytes(addr_out, sizeof(addr_out), hrp, data2, sizeof(data2), 0);
+        err = bech32EncodeFromBytes(addr_out, sizeof(addr_out), hrp, data2, sizeof(data2), 0, BECH32_ENCODING_BECH32);
         ASSERT_EQ(err, zxerr_ok);
         std::cout << addr_out << std::endl;
         ASSERT_STREQ("zx1qyps2pcfpvx20dk22", addr_out);
 
         ///
-        err = bech32EncodeFromBytes(addr_out, sizeof(addr_out), hrp, data1, sizeof(data1), 1);
+        err = bech32EncodeFromBytes(addr_out, sizeof(addr_out), hrp, data1, sizeof(data1), 1,BECH32_ENCODING_BECH32);
         ASSERT_EQ(err, zxerr_ok);
         std::cout << addr_out << std::endl;
         ASSERT_STREQ("zx1qyps2ucfnzd", addr_out);
 
-        err = bech32EncodeFromBytes(addr_out, sizeof(addr_out), hrp, data2, sizeof(data2), 1);
+        err = bech32EncodeFromBytes(addr_out, sizeof(addr_out), hrp, data2, sizeof(data2), 1, BECH32_ENCODING_BECH32);
         ASSERT_EQ(err, zxerr_ok);
         std::cout << addr_out << std::endl;
         ASSERT_STREQ("zx1qyps2pcfpvxshamanz", addr_out);
@@ -54,7 +54,7 @@ namespace {
 
         auto data = std::vector<uint8_t>(1000, 0x55);
 
-        auto err = bech32EncodeFromBytes(addr_out, sizeof(addr_out), hrp, data.data(), data.size(),0);
+        auto err = bech32EncodeFromBytes(addr_out, sizeof(addr_out), hrp, data.data(), data.size(),0, BECH32_ENCODING_BECH32);
         ASSERT_EQ(err, zxerr_out_of_bounds);
 
         std::cout << addr_out << std::endl;
@@ -71,7 +71,69 @@ namespace {
         // declare size to be smaller
         const size_t declared_size = 52;
 
-        auto err = bech32EncodeFromBytes(addr_out, declared_size, hrp, data.data(), data.size(), 0);
+        auto err = bech32EncodeFromBytes(addr_out, declared_size, hrp, data.data(), data.size(), 0, BECH32_ENCODING_BECH32);
+        ASSERT_EQ(err, zxerr_buffer_too_small);
+
+        for (int i = declared_size; i < sizeof(addr_out); i++) {
+            ASSERT_EQ(addr_out[i], 0);
+        }
+
+        std::cout << addr_out << std::endl;
+    }
+
+    TEST(BECH32M, hex_to_address) {
+        char addr_out[100];
+        const char *hrp = "zx";
+
+        uint8_t data1[] = {1, 3, 5};
+        uint8_t data2[] = {1, 3, 5, 7, 9, 11, 13};
+
+        auto err = bech32EncodeFromBytes(addr_out, sizeof(addr_out), hrp, data1, sizeof(data1), 0, BECH32_ENCODING_BECH32M);
+        ASSERT_EQ(err, zxerr_ok);
+        std::cout << addr_out << std::endl;
+        ASSERT_STREQ("zx1qypsvm6cc6", addr_out);
+
+        err = bech32EncodeFromBytes(addr_out, sizeof(addr_out), hrp, data2, sizeof(data2), 0, BECH32_ENCODING_BECH32M);
+        ASSERT_EQ(err, zxerr_ok);
+        std::cout << addr_out << std::endl;
+        ASSERT_STREQ("zx1qyps2pcfpvxlna60g", addr_out);
+
+        ///
+        err = bech32EncodeFromBytes(addr_out, sizeof(addr_out), hrp, data1, sizeof(data1), 1,BECH32_ENCODING_BECH32M);
+        ASSERT_EQ(err, zxerr_ok);
+        std::cout << addr_out << std::endl;
+        ASSERT_STREQ("zx1qyps2fyel80", addr_out);
+
+        err = bech32EncodeFromBytes(addr_out, sizeof(addr_out), hrp, data2, sizeof(data2), 1, BECH32_ENCODING_BECH32M);
+        ASSERT_EQ(err, zxerr_ok);
+        std::cout << addr_out << std::endl;
+        ASSERT_STREQ("zx1qyps2pcfpvxszpt3kq", addr_out);
+    }
+
+    TEST(BECH32M, huge_input) {
+        char addr_out[200];
+        const char *hrp = "zx";
+
+        auto data = std::vector<uint8_t>(1000, 0x55);
+
+        auto err = bech32EncodeFromBytes(addr_out, sizeof(addr_out), hrp, data.data(), data.size(),0, BECH32_ENCODING_BECH32M);
+        ASSERT_EQ(err, zxerr_out_of_bounds);
+
+        std::cout << addr_out << std::endl;
+    }
+
+    TEST(BECH32M, small_output) {
+        char addr_out[1000];
+        const char *hrp = "zx";
+
+        auto data = std::vector<uint8_t>(32, 0x55);
+
+        MEMZERO(addr_out, sizeof(addr_out));
+
+        // declare size to be smaller
+        const size_t declared_size = 52;
+
+        auto err = bech32EncodeFromBytes(addr_out, declared_size, hrp, data.data(), data.size(), 0, BECH32_ENCODING_BECH32M);
         ASSERT_EQ(err, zxerr_buffer_too_small);
 
         for (int i = declared_size; i < sizeof(addr_out); i++) {


### PR DESCRIPTION
add the option to chose bech32 or bech32m encoding.
The latter solves a (minor) security issue by using a different checksum.

<!-- ClickUpRef: 38fra2h -->
:link: [zboto Link](https://app.clickup.com/t/38fra2h)