### PR TITLE
Updates v2

### DIFF
--- a/app/ui/view_internal.h
+++ b/app/ui/view_internal.h
@@ -29,6 +29,7 @@
 #define MAX_CHARS_PER_VALUE1_LINE   4096
 #define MAX_CHARS_HEXMESSAGE        160
 #elif defined(TARGET_STAX)
+#include "nbgl_use_case.h"
 #define MAX_CHARS_PER_KEY_LINE      64
 #define MAX_CHARS_PER_VALUE1_LINE   180
 #define MAX_CHARS_HEXMESSAGE        160
@@ -79,16 +80,13 @@ static const char* shortcut_value = SHORTCUT_VALUE;
     #define INTRO_PAGES 0
 #endif
 
-#define FIELDS_PER_PAGE 4
-#define MAX_LINES_PER_FIELD 8
-
 typedef struct {
     struct {
 #if defined(TARGET_STAX)
         char* key;
         char* value;
-        char keys[FIELDS_PER_PAGE][MAX_CHARS_PER_KEY_LINE];
-        char values[FIELDS_PER_PAGE][MAX_CHARS_PER_VALUE1_LINE];
+        char keys[NB_MAX_DISPLAYED_PAIRS_IN_REVIEW][MAX_CHARS_PER_KEY_LINE];
+        char values[NB_MAX_DISPLAYED_PAIRS_IN_REVIEW][MAX_CHARS_PER_VALUE1_LINE];
 #else
         char key[MAX_CHARS_PER_KEY_LINE];
         char value[MAX_CHARS_PER_VALUE1_LINE];

--- a/include/zxmacros.h
+++ b/include/zxmacros.h
@@ -15,13 +15,13 @@
 ********************************************************************************/
 #pragma once
 
+#ifdef __cplusplus
 #pragma clang diagnostic push
 #pragma ide diagnostic ignored "modernize-use-nullptr"
 #pragma ide diagnostic ignored "OCUnusedGlobalDeclarationInspection"
 #pragma ide diagnostic ignored "OCUnusedMacroInspection"
 #pragma ide diagnostic ignored "modernize-deprecated-headers"
 
-#ifdef __cplusplus
 extern "C" {
 #endif
 
@@ -119,6 +119,6 @@ __Z_INLINE void zemu_log(__Z_UNUSED const char *msg) {
 
 #ifdef __cplusplus
 }
+#pragma clang diagnostic pop
 #endif
 
-#pragma clang diagnostic pop

--- a/include/zxversion.h
+++ b/include/zxversion.h
@@ -17,4 +17,4 @@
 
 #define ZXLIB_MAJOR     17
 #define ZXLIB_MINOR     2
-#define ZXLIB_PATCH     1
+#define ZXLIB_PATCH     2

--- a/makefiles/Makefile.app_testing
+++ b/makefiles/Makefile.app_testing
@@ -1,6 +1,6 @@
 #*******************************************************************************
 #  Ledger App
-#  (c) 2018 - 2022 Zondax AG
+#  (c) 2018 - 2023 Zondax AG
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.

--- a/makefiles/Makefile.c_app
+++ b/makefiles/Makefile.c_app
@@ -1,6 +1,6 @@
 #*******************************************************************************
 #  Ledger App
-#  (c) 2018 - 2022 Zondax AG
+#  (c) 2018 - 2023 Zondax AG
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.
@@ -19,9 +19,6 @@
 rust:
 	@echo "No rust code"
 #	cd rust && CARGO_HOME="$(CURDIR)/rust/.cargo" cargo build --target thumbv6m-none-eabi --release
-
-# Before linking, we need to be sure rust lib is there
-bin/app.elf: rust
 
 .PHONY: rust_clean
 rust_clean:

--- a/makefiles/Makefile.devices
+++ b/makefiles/Makefile.devices
@@ -1,6 +1,6 @@
 #*******************************************************************************
 #  Ledger App
-#  (c) 2018 - 2022 Zondax AG
+#  (c) 2018 - 2023 Zondax AG
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.

--- a/makefiles/Makefile.installer_script
+++ b/makefiles/Makefile.installer_script
@@ -1,6 +1,6 @@
 #*******************************************************************************
 #  Ledger App
-#  (c) 2018 - 2022 Zondax AG
+#  (c) 2018 - 2023 Zondax AG
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.

--- a/makefiles/Makefile.platform
+++ b/makefiles/Makefile.platform
@@ -1,6 +1,6 @@
 #*******************************************************************************
 #  Ledger App
-#  (c) 2018 - 2022 Zondax AG
+#  (c) 2018 - 2023 Zondax AG
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.
@@ -91,13 +91,11 @@ endif
 #########################
 
 CC := $(CLANGPATH)clang
-CFLAGS += -O3 -Os -Wno-unknown-pragmas -Wno-unused-parameter
 
 AS := $(GCCPATH)arm-none-eabi-gcc
 AFLAGS +=
 
 LD       := $(GCCPATH)arm-none-eabi-gcc
-LDFLAGS  += -O3 -Os
 LDLIBS   += -lm -lgcc -lc
 
 ##########################

--- a/makefiles/Makefile.side_loading
+++ b/makefiles/Makefile.side_loading
@@ -1,6 +1,6 @@
 #*******************************************************************************
 #  Ledger App
-#  (c) 2018 - 2022 Zondax AG
+#  (c) 2018 - 2023 Zondax AG
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.

--- a/src/zxmacros.c
+++ b/src/zxmacros.c
@@ -15,8 +15,10 @@
 ********************************************************************************/
 #include "zxmacros.h"
 
+#ifdef __cplusplus
 #pragma clang diagnostic push
 #pragma ide diagnostic ignored "EndlessLoop"
+#endif
 
 void handle_stack_overflow() {
     zemu_log("!!!!!!!!!!!!!!!!!!!!!! CANARY TRIGGERED!!! STACK OVERFLOW DETECTED\n");
@@ -27,7 +29,9 @@ void handle_stack_overflow() {
 #endif
 }
 
+#ifdef __cplusplus
 #pragma clang diagnostic pop
+#endif
 
 __Z_UNUSED void check_app_canary() {
 #if defined (TARGET_NANOS) || defined(TARGET_NANOX) || defined(TARGET_NANOS2) || defined(TARGET_STAX)


### PR DESCRIPTION
Remove `bin/app.elf` and use `default` instead when needed
Remove `CFLAGS` and `LDFLAGS` from `Makefile.platform` since they are included now in the SDK
Some rework in `view_stax` to rely on SDK methods and simplify logic
Remove unnecessary cast
Update copyright


<!-- ClickUpRef: 861mm71ub -->
:link: [zboto Link](https://app.clickup.com/t/861mm71ub)