### PR TITLE
QR code source path is now used explicitly

### DIFF
--- a/include/zxversion.h
+++ b/include/zxversion.h
@@ -17,4 +17,4 @@
 
 #define ZXLIB_MAJOR     19
 #define ZXLIB_MINOR     7
-#define ZXLIB_PATCH     0
+#define ZXLIB_PATCH     1

--- a/makefiles/Makefile.platform
+++ b/makefiles/Makefile.platform
@@ -42,6 +42,7 @@ else ifeq ($(TARGET_NAME),TARGET_STAX)
 # Stax
 	DEFINES += IO_SEPROXYHAL_BUFFER_SIZE_B=300
 	DEFINES += NBGL_QRCODE
+	SDK_SOURCE_PATH += qrcode
 
 #	Required by SDK
 	DEFINES += UNUSED\(x\)=\(void\)x


### PR DESCRIPTION
In anticipation of this PR : https://github.com/LedgerHQ/ledger-secure-sdk/pull/397
There is a breaking change for Stax applications using the QR code feature relying on the SDK to have it already in its source path.