### PR TITLE
Add new macro

### DIFF
--- a/app/ui/view_internal.h
+++ b/app/ui/view_internal.h
@@ -21,6 +21,7 @@
 #include "coin.h"
 #include "zxerror.h"
 #include "view.h"
+#include "zxmacros.h"
 
 #define CUR_FLOW G_ux.flow_stack[G_ux.stack_count-1]
 

--- a/include/segwit_addr.h
+++ b/include/segwit_addr.h
@@ -23,6 +23,7 @@
 #define _SEGWIT_ADDR_H_ 1
 
 #include <stdint.h>
+#include <stddef.h>
 
 /** Encode a SegWit address
  *

--- a/include/zxerror.h
+++ b/include/zxerror.h
@@ -16,8 +16,6 @@
 
 #pragma once
 
-#include "zxmacros.h"
-
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -36,40 +34,6 @@ typedef enum {
     zxerr_invalid_crypto_settings = 0b00001100,
     zxerr_ledger_api_error = 0b00001111,
 } zxerr_t;
-
-__Z_INLINE uint8_t getErrorMessage(char *buffer, uint16_t bufferLen, zxerr_t err) {
-    MEMZERO(buffer, bufferLen);
-    if (bufferLen == 0) {
-        return 0;
-    }
-
-    switch (err) {
-        case zxerr_unknown:
-            snprintf(buffer, bufferLen - 1, "zxerr_unknown");
-            break;
-        case zxerr_ok:
-            snprintf(buffer, bufferLen - 1, "zxerr_ok");
-            break;
-        case zxerr_no_data:
-            snprintf(buffer, bufferLen - 1, "zxerr_no_data");
-            break;
-        case zxerr_out_of_bounds:
-            snprintf(buffer, bufferLen - 1, "zxerr_out_of_bounds");
-            break;
-        case zxerr_encoding_failed:
-            snprintf(buffer, bufferLen - 1, "zxerr_encoding_failed");
-            break;
-        case zxerr_invalid_crypto_settings:
-            snprintf(buffer, bufferLen - 1, "zxerr_invalid_crypto_settings");
-            break;
-        case zxerr_ledger_api_error:
-            snprintf(buffer, bufferLen - 1, "zxerr_ledger_api_error");
-            break;
-        default:
-            snprintf(buffer, bufferLen - 1, "err N/A");
-    }
-    return strlen(buffer);
-}
 
 //0b00000000
 //0b00000011

--- a/include/zxmacros_ledger.h
+++ b/include/zxmacros_ledger.h
@@ -21,6 +21,7 @@
 #include "cx.h"
 #include "os_io_seproxyhal.h"
 #include "ux.h"
+#include "zxerror.h"
 
 #define MEMCPY_NV nvm_write
 
@@ -67,7 +68,7 @@ extern unsigned int app_stack_canary;
     if (__cx_err != CX_OK) {   \
       return __cx_err;         \
     }                          \
-  } while (0);
+  } while (0)
 
 
 #define CATCH_CXERROR(CALL)    \
@@ -76,6 +77,14 @@ extern unsigned int app_stack_canary;
     if (__cx_err != CX_OK) {   \
       goto catch_cx_error;     \
     }                          \
-  } while (0);
+  } while (0)
+
+#define CHECK_CX_OK(CALL)      \
+  do {                         \
+    cx_err_t __cx_err = CALL;  \
+    if (__cx_err != CX_OK) {   \
+      return zxerr_unknown;    \
+    }                          \
+  } while (0)
 
 #endif

--- a/include/zxversion.h
+++ b/include/zxversion.h
@@ -15,6 +15,6 @@
 ********************************************************************************/
 #pragma once
 
-#define ZXLIB_MAJOR     20
+#define ZXLIB_MAJOR     21
 #define ZXLIB_MINOR     0
 #define ZXLIB_PATCH     0


### PR DESCRIPTION
- Add `CHECK_CX_OK` that will return `zxerr_unknown` if the return code is different from `CX_OK`. This is needed to add checks for SDK methods and make the static analyzer happy.

- Removed semicolon from macros to enforce the addition of a final semicolon when the app uses these macros.