### PR TITLE
Replace uint16_t with size_t for Buffer size definitions

### DIFF
--- a/include/buffering.h
+++ b/include/buffering.h
@@ -26,8 +26,8 @@ extern "C" {
 
 typedef struct {
     uint8_t *data;
-    uint16_t size;
-    uint16_t pos;
+    size_t size;
+    size_t pos;
     uint8_t in_use: 1;
 } buffer_state_t;
 
@@ -37,9 +37,9 @@ typedef struct {
 /// \param flash_buffer
 /// \param flash_buffer_size
 void buffering_init(uint8_t *ram_buffer,
-                    uint16_t ram_buffer_size,
+                    size_t ram_buffer_size,
                     uint8_t *flash_buffer,
-                    uint16_t flash_buffer_size);
+                    size_t flash_buffer_size);
 
 /// Reset buffer
 void buffering_reset();
@@ -48,7 +48,7 @@ void buffering_reset();
 /// \param data
 /// \param length
 /// \return the number of appended bytes
-int buffering_append(uint8_t *data, int length);
+int buffering_append(uint8_t *data, size_t length);
 
 /// buffering_get_ram_buffer
 /// \return

--- a/include/zxversion.h
+++ b/include/zxversion.h
@@ -17,4 +17,4 @@
 
 #define ZXLIB_MAJOR 28
 #define ZXLIB_MINOR 0
-#define ZXLIB_PATCH 6
+#define ZXLIB_PATCH 7

--- a/src/buffering.c
+++ b/src/buffering.c
@@ -25,9 +25,9 @@ buffer_state_t ram;         // Ram
 buffer_state_t flash;       // Flash
 
 void buffering_init(uint8_t *ram_buffer,
-                    uint16_t ram_buffer_size,
+                    size_t ram_buffer_size,
                     uint8_t *flash_buffer,
-                    uint16_t flash_buffer_size) {
+                    size_t flash_buffer_size) {
     ram.data = ram_buffer;
     ram.size = ram_buffer_size;
     ram.pos = 0;
@@ -46,11 +46,11 @@ void buffering_reset() {
     flash.in_use = 0;
 }
 
-int buffering_append(uint8_t *data, int length) {
+int buffering_append(uint8_t *data, size_t length) {
     if (ram.in_use) {
         if (ram.size - ram.pos >= length) {
             // RAM in use, append to ram if there is enough space
-            MEMCPY(ram.data + ram.pos, data, (size_t) length);
+            MEMCPY(ram.data + ram.pos, data, length);
             ram.pos += length;
         } else {
             // If RAM is not big enough copy memory to flash
@@ -66,7 +66,7 @@ int buffering_append(uint8_t *data, int length) {
     } else {
         // Flash in use, append to flash
         if (flash.size - flash.pos >= length) {
-            MEMCPY_NV(flash.data + flash.pos, data, (size_t) length);
+            MEMCPY_NV(flash.data + flash.pos, data, length);
             flash.pos += length;
         } else {
             return 0;


### PR DESCRIPTION
This pull request updates the codebase by replacing instances of uint16_t used for size representations with size_t, in alignment with coding guidelines that specify sizes should be defined using size_t. This change also eliminates unnecessary internal type conversions and allows for larger buffer definitions.

Users are not affected by this change. Functions like `sizeof()` already return a size_t type, so existing code that relies on these functions will continue to work seamlessly, and They can now define and work with larger buffers without encountering integer overflow issues associated with uint16_t.