### PR TITLE
Fix pointer arithmetic on canary placement

### DIFF
--- a/include/zxversion.h
+++ b/include/zxversion.h
@@ -16,5 +16,5 @@
 #pragma once
 
 #define ZXLIB_MAJOR 29
-#define ZXLIB_MINOR 0
+#define ZXLIB_MINOR 2
 #define ZXLIB_PATCH 0

--- a/src/zxcanary.c
+++ b/src/zxcanary.c
@@ -20,7 +20,7 @@
 
 // This symbol is defined by the link script to be at the start of the stack area.
 extern unsigned int app_stack_canary;
-#define ZONDAX_CANARY (*((volatile uint32_t*) (&app_stack_canary + sizeof(uint32_t))))
+#define ZONDAX_CANARY (*((volatile uint32_t*) (((uint8_t*) &app_stack_canary) + sizeof(uint32_t))))
 
 #if defined(HAVE_ZONDAX_CANARY)
 #include "errors.h"


### PR DESCRIPTION
Canary was placed 16 bytes beyond the stack instead of 4.

<!-- ClickUpRef: 86965bv5u -->
:link: [zboto Link](https://app.clickup.com/t/86965bv5u)