### PR TITLE
feat: replace deprecated homeAndSetting fns

### DIFF
--- a/app/ui/view_nbgl.c
+++ b/app/ui/view_nbgl.c
@@ -68,7 +68,7 @@ typedef enum {
 #ifdef APP_BLINDSIGN_MODE_ENABLED
     BLINDSIGN_MODE,
 #endif
-    SETTINGS_SWITCHES_NB
+    SETTINGS_SWITCHES_NB_LEN
 } settings_list_e;
 
 typedef enum {
@@ -98,7 +98,7 @@ static const char *const INFO_VALUES_PAGE[] = {APPVERSION, "Zondax AG", "https:/
 
 static nbgl_contentInfoList_t infoList = {0};
 static nbgl_genericContents_t settingContents = {0};
-static nbgl_contentSwitch_t switches[4];
+static nbgl_contentSwitch_t switches[SETTINGS_SWITCHES_NB_LEN];
 
 static void h_expert_toggle() { app_mode_set_expert(!app_mode_expert()); }
 
@@ -320,7 +320,7 @@ static void settings_screen_callback(uint8_t index, nbgl_content_t *content) {
 #endif
 
     content->type = SWITCHES_LIST;
-    content->content.switchesList.nbSwitches = SETTINGS_SWITCHES_NB;
+    content->content.switchesList.nbSwitches = SETTINGS_SWITCHES_NB_LEN;
     content->content.switchesList.switches = switches;
     content->contentActionCallback = settings_toggle_callback;
 }

--- a/app/ui/view_nbgl.c
+++ b/app/ui/view_nbgl.c
@@ -287,12 +287,14 @@ static void settings_screen_callback(uint8_t index, nbgl_content_t *content) {
     UNUSED(index);
     switches[EXPERT_MODE].initState = app_mode_expert();
     switches[EXPERT_MODE].text = "Expert mode";
+    switches[EXPERT_MODE].subText = "";
     switches[EXPERT_MODE].tuneId = TUNE_TAP_CASUAL;
     switches[EXPERT_MODE].token = EXPERT_MODE_TOKEN;
 
 #ifdef APP_BLINDSIGN_MODE_ENABLED
     switches[BLINDSIGN_MODE].initState = app_mode_blindsign();
     switches[BLINDSIGN_MODE].text = "Blind sign";
+    switches[BLINDSIGN_MODE].subText = "";
     switches[BLINDSIGN_MODE].tuneId = TUNE_TAP_CASUAL;
     switches[BLINDSIGN_MODE].token = BLINDSIGN_MODE_TOKEN;
 #endif
@@ -301,6 +303,7 @@ static void settings_screen_callback(uint8_t index, nbgl_content_t *content) {
     if (app_mode_expert() || app_mode_account()) {
         switches[ACCOUNT_MODE].initState = app_mode_account();
         switches[ACCOUNT_MODE].text = "Crowdloan account";
+        switches[ACCOUNT_MODE].subText = "";
         switches[ACCOUNT_MODE].tuneId = TUNE_TAP_CASUAL;
         switches[ACCOUNT_MODE].token = ACCOUNT_MODE_TOKEN;
             }
@@ -310,6 +313,7 @@ static void settings_screen_callback(uint8_t index, nbgl_content_t *content) {
     if (app_mode_expert() || app_mode_secret()) {
         switches[SECRET_MODE].initState = app_mode_secret();
         switches[SECRET_MODE].text = "Secret mode";
+        switches[SECRET_MODE].subText = "";
         switches[SECRET_MODE].tuneId = TUNE_TAP_CASUAL;
         switches[SECRET_MODE].token = SECRET_MODE_TOKEN;
     }

--- a/dockerized_build.mk
+++ b/dockerized_build.mk
@@ -49,7 +49,7 @@ $(info TESTS_ZEMU_DIR        : $(TESTS_ZEMU_DIR))
 $(info TESTS_JS_DIR          : $(TESTS_JS_DIR))
 $(info TESTS_JS_PACKAGE      : $(TESTS_JS_PACKAGE))
 
-DOCKER_IMAGE_ZONDAX=zondax/ledger-app-builder:ledger-551b75905dc19998845d5ec70e179707024abe10
+DOCKER_IMAGE_ZONDAX=zondax/ledger-app-builder:ledger-f8919f571939ec75e24d0e0cb35ee50c02bc8c0e
 DOCKER_IMAGE_LEDGER=ghcr.io/ledgerhq/ledger-app-builder/ledger-app-builder:latest
 
 ifdef INTERACTIVE

--- a/include/zxversion.h
+++ b/include/zxversion.h
@@ -16,5 +16,5 @@
 #pragma once
 
 #define ZXLIB_MAJOR 29
-#define ZXLIB_MINOR 3
+#define ZXLIB_MINOR 4
 #define ZXLIB_PATCH 0


### PR DESCRIPTION
Some deprecated functions were used to display home and settings on stax and flex. Use the new functions to solve warnings. There is a new field for each setting field, called subText. It gives space for some short sentence about that setting flag. For now, we are leaving it as empty for all our flags. We could change this in future releases.