### PR TITLE
Feat/skip menu

### DIFF
--- a/app/ui/view.c
+++ b/app/ui/view.c
@@ -52,17 +52,24 @@ void view_review_init(viewfunc_getItem_t viewfuncGetItem, viewfunc_getNumItems_t
     viewdata.viewfuncGetItem = viewfuncGetItem;
     viewdata.viewfuncGetNumItems = viewfuncGetNumItems;
     viewdata.viewfuncAccept = viewfuncAccept;
+
+#if defined(TARGET_NANOS) || defined(TARGET_NANOS2) || defined(TARGET_NANOX)
     viewdata.with_confirmation = false;
+#endif
+
 }
 
 void view_review_init_progressive(
     viewfunc_getItem_t viewfuncGetItem,
     viewfunc_getNumItems_t viewfuncGetNumItems,
     viewfunc_accept_t viewfuncAccept) {
-    viewdata.viewfuncGetItem = viewfuncGetItem;
-    viewdata.viewfuncGetNumItems = viewfuncGetNumItems;
-    viewdata.viewfuncAccept = viewfuncAccept;
+
+    view_review_init(viewfuncGetItem, viewfuncGetNumItems, viewfuncAccept);
+
+#if defined(TARGET_NANOS) || defined(TARGET_NANOS2) || defined(TARGET_NANOX)
     viewdata.with_confirmation = true;
+#endif
+
 }
 
 void view_initialize_init(viewfunc_initialize_t viewFuncInit) { viewdata.viewfuncInitialize = viewFuncInit; }

--- a/app/ui/view.c
+++ b/app/ui/view.c
@@ -52,6 +52,17 @@ void view_review_init(viewfunc_getItem_t viewfuncGetItem, viewfunc_getNumItems_t
     viewdata.viewfuncGetItem = viewfuncGetItem;
     viewdata.viewfuncGetNumItems = viewfuncGetNumItems;
     viewdata.viewfuncAccept = viewfuncAccept;
+    viewdata.with_confirmation = false;
+}
+
+void view_review_init_progressive(
+    viewfunc_getItem_t viewfuncGetItem,
+    viewfunc_getNumItems_t viewfuncGetNumItems,
+    viewfunc_accept_t viewfuncAccept) {
+    viewdata.viewfuncGetItem = viewfuncGetItem;
+    viewdata.viewfuncGetNumItems = viewfuncGetNumItems;
+    viewdata.viewfuncAccept = viewfuncAccept;
+    viewdata.with_confirmation = true;
 }
 
 void view_initialize_init(viewfunc_initialize_t viewFuncInit) { viewdata.viewfuncInitialize = viewFuncInit; }

--- a/app/ui/view.h
+++ b/app/ui/view.h
@@ -81,6 +81,9 @@ typedef void (*viewfunc_accept_t)();
 
 typedef zxerr_t (*viewfunc_initialize_t)();
 
+// Callback type for continuation confirmation
+typedef void (*viewfunc_confirm_continue_t)(char *outKey, uint16_t outKeyLen, char *outVal, uint16_t outValLen);
+
 typedef enum {
     REVIEW_UI = 0,
     REVIEW_ADDRESS,
@@ -115,6 +118,11 @@ void view_blindsign_error_show();
 
 void view_review_init(viewfunc_getItem_t viewfuncGetItem, viewfunc_getNumItems_t viewfuncGetNumItems,
                       viewfunc_accept_t viewfuncAccept);
+
+void view_review_init_progressive(
+    viewfunc_getItem_t viewfuncGetItem,
+    viewfunc_getNumItems_t viewfuncGetNumItems,
+    viewfunc_accept_t viewfuncAccept);
 
 void view_inspect_init(viewfunc_getInnerItem_t view_funcGetInnerItem, viewfunc_getNumItems_t view_funcGetInnerNumItems,
                        viewfunc_canInspectItem_t view_funcCanInspectItem);

--- a/app/ui/view_internal.h
+++ b/app/ui/view_internal.h
@@ -152,11 +152,28 @@ typedef struct {
     uint8_t pageCount;
 
     inner_state_t innerField;
-    // Use to tell the engine to ask
-    // the user if they want to continue
-    // with the review, otherwise, go to the final
-    // approval and proceed to sign the transaction
+#if defined(TARGET_NANOS) || defined(TARGET_NANOS2) || defined(TARGET_NANOX)
+    /**
+     * @brief Determines whether to prompt the user for confirmation during the review process.
+     *
+     * When `with_confirmation` is set to `true`, the engine will display a confirmation prompt
+     * to the user after each item review. This allows the user to either continue reviewing items
+     * or proceed to the final approval step.
+     *
+     * If `with_confirmation` is set to `false`, the engine will skip the confirmation prompts
+     * forcing users to review all items until they get to the approval menu.
+     *
+     * **Applicable Targets:**
+     * - Ledger Nano S (TARGET_NANOS)
+     * - Ledger Nano S2 (TARGET_NANOS2)
+     * - Ledger Nano X (TARGET_NANOX)
+     *
+     * **Excluded Targets:**
+     * - Stax
+     * - Flex
+     */
     bool with_confirmation;
+#endif
 } view_t;
 
 typedef enum {

--- a/app/ui/view_internal.h
+++ b/app/ui/view_internal.h
@@ -152,6 +152,11 @@ typedef struct {
     uint8_t pageCount;
 
     inner_state_t innerField;
+    // Use to tell the engine to ask
+    // the user if they want to continue
+    // with the review, otherwise, go to the final
+    // approval and proceed to sign the transaction
+    bool with_confirmation;
 } view_t;
 
 typedef enum {

--- a/app/ui/view_s.c
+++ b/app/ui/view_s.c
@@ -211,11 +211,11 @@ bool should_show_skip_menu_right() {
     return viewdata.with_confirmation &&
         (review_type == REVIEW_TXN || review_type == REVIEW_MSG) &&
         // To enable left arrow rendering
-        viewdata.pageIdx > 0                      &&
-        // Not in reject screen
+        viewdata.pageIdx > 0                       &&
         viewdata.pageIdx == viewdata.pageCount - 1 &&
         // Not in approve screen
-        viewdata.itemIdx != viewdata.itemCount - 2 &&
+        // Not in reject screen
+        !is_accept_item()                          &&
         !is_reject_item();
 }
 
@@ -225,9 +225,10 @@ bool should_show_skip_menu_left() {
         (review_type == REVIEW_TXN || review_type == REVIEW_MSG) &&
         viewdata.itemIdx > 0 &&                     // Not the first item
         viewdata.pageIdx == 0 &&                    // Reached first page of current item
-        !is_reject_item() &&
+        // Not in approve screen
+        // Not in reject screen
         !is_accept_item() &&
-        viewdata.itemIdx < viewdata.itemCount - 2;  // Not in final screens
+        !is_reject_item();
 }
 
 static unsigned int view_review_button(unsigned int button_mask, unsigned int button_mask_counter) {
@@ -245,8 +246,7 @@ static unsigned int view_review_button(unsigned int button_mask, unsigned int bu
                 is_in_skip_menu = true;
                 UX_DISPLAY(view_skip, view_prepro);
             } else {
-                h_paging_decrease();
-                h_review_update();
+                h_review_button_left();
             }
             break;
 

--- a/app/ui/view_s.c
+++ b/app/ui/view_s.c
@@ -316,6 +316,19 @@ void h_review_button_right() {
 }
 
 static void h_review_action(unsigned int requireReply) {
+    if (viewdata.with_confirmation &&
+        (review_type == REVIEW_TXN || review_type == REVIEW_MSG) &&
+        viewdata.pageIdx == viewdata.pageCount - 1 &&
+        viewdata.itemIdx < viewdata.itemCount - 2) {
+        // Force jump to approval screen
+        viewdata.itemIdx = viewdata.itemCount - 1;
+        viewdata.pageIdx = 0;
+
+        h_review_update();
+
+        return;
+    }
+
     if( is_accept_item() ){
         zemu_log_stack("action_accept");
         h_approve(1);

--- a/app/ui/view_s.c
+++ b/app/ui/view_s.c
@@ -197,7 +197,7 @@ static unsigned int view_message_button(unsigned int button_mask, __Z_UNUSED uns
     }
     return 0;
 }
-// Modify review button handler to show skip screen when appropriate
+
 static unsigned int view_review_button(unsigned int button_mask, unsigned int button_mask_counter) {
     switch (button_mask) {
         case BUTTON_EVT_RELEASED | BUTTON_LEFT | BUTTON_RIGHT:
@@ -206,13 +206,16 @@ static unsigned int view_review_button(unsigned int button_mask, unsigned int bu
         case BUTTON_EVT_RELEASED | BUTTON_LEFT:
             h_review_button_left();
             break;
+        // Are we at the point to display the skip/continue menu?
+        // for this with_cnfirmation must set
         case BUTTON_EVT_RELEASED | BUTTON_RIGHT:
             if (viewdata.with_confirmation &&
                 (review_type == REVIEW_TXN || review_type == REVIEW_MSG) &&
                 viewdata.pageIdx == viewdata.pageCount - 1 &&
-                viewdata.itemIdx < viewdata.itemCount - 1) {
-                // Show skip screen
-                UX_DISPLAY(view_skip, view_prepro);
+                // Render the skip screen after each item except the last one.
+                // For the last item, navigate directly to the approval screen.
+                viewdata.itemIdx != viewdata.itemCount - 2) {
+                    UX_DISPLAY(view_skip, view_prepro);
             } else {
                 h_review_button_right();
             }

--- a/app/ui/view_x.c
+++ b/app/ui/view_x.c
@@ -375,6 +375,8 @@ void h_review_loop_end() {
                     ux_review_flow[index++] = &ux_review_skip_step;
                     ux_review_flow[index++] = FLOW_END_STEP;
                     ux_flow_init(0, ux_review_flow, NULL);
+                    // set the callback before flow initialization, otherwise
+                    // it would be overwritten
                     set_button_callback();
                     return;
                 }
@@ -649,7 +651,6 @@ static unsigned int handle_button_push(unsigned int button_mask, unsigned int bu
     switch (button_mask) {
         // Handle skip to approve
         case BUTTON_EVT_RELEASED | BUTTON_LEFT | BUTTON_RIGHT:
-            G_ux.stack[0].button_push_callback = NULL;
             if (review_type == REVIEW_MSG) {
                 run_ux_review_flow((review_type_e)review_type, &ux_review_flow_6_step);
             } else {
@@ -661,8 +662,13 @@ static unsigned int handle_button_push(unsigned int button_mask, unsigned int bu
         // Handle continue review
         case BUTTON_EVT_RELEASED | BUTTON_RIGHT:
             viewdata.itemIdx++;
-            // Temporarily disable callback to prevent double processing
+            run_ux_review_flow((review_type_e)review_type, &ux_review_flow_2_start_step);
+            reset_button_callback();
+            return 1;
+
+        case BUTTON_EVT_RELEASED | BUTTON_LEFT:
             G_ux.stack[0].button_push_callback = NULL;
+            // h_paging_init();
             run_ux_review_flow((review_type_e)review_type, &ux_review_flow_2_start_step);
             reset_button_callback();
             return 1;

--- a/app/ui/view_x.c
+++ b/app/ui/view_x.c
@@ -365,7 +365,8 @@ void h_review_loop_end() {
                 // If we're at the end of current item and there's more to show
                 if (viewdata.with_confirmation &&
                     (review_type == REVIEW_TXN || review_type == REVIEW_MSG) &&
-                    viewdata.pageIdx == viewdata.pageCount - 1 &&
+                    viewdata.pageIdx == viewdata.pageCount - 1               &&
+                    viewdata.itemIdx > getIntroPages()                       &&
                     viewdata.itemIdx < viewdata.itemCount - 1) {
 
                     // Show skip screen and enable button handler

--- a/app/ui/view_x.c
+++ b/app/ui/view_x.c
@@ -117,6 +117,7 @@ UX_STEP_NOCB(
       "Press right to read",
       "Double-press to skip"
     });
+UX_STEP_NOCB(ux_review_skip_page, bnnn_paging, { .title = viewdata.key, .text = viewdata.value, });
 
 #ifdef APP_SECRET_MODE_ENABLED
 UX_STEP_CB(ux_idle_flow_4_step, bn, h_secret_click(),
@@ -357,7 +358,6 @@ void h_review_loop_end() {
         // coming from left
         h_paging_increase();
         zxerr_t err = h_review_update_data();
-        reset_button_callback();
 
         switch (err) {
             case zxerr_ok:
@@ -680,6 +680,6 @@ static void set_button_callback(void) {
 static void reset_button_callback(void) {
     custom_callback_active = false;
     G_ux.stack[0].button_push_callback = original_button_callback;
-    original_button_callback = NULL;
+    // original_button_callback = NULL;
 }
 #endif

--- a/app/ui/view_x.c
+++ b/app/ui/view_x.c
@@ -361,7 +361,13 @@ void h_review_loop_end() {
                 if (viewdata.with_confirmation &&
                     (review_type == REVIEW_TXN || review_type == REVIEW_MSG) &&
                     viewdata.pageIdx == viewdata.pageCount - 1               &&
-                    viewdata.itemIdx > getIntroPages() + 1                   &&
+                    // Ensure that at least the first item is displayed.
+                    // The UI design may vary between applications. For example, item 0 might
+                    // serve as a title for the transaction type rather than a regular item.
+                    // In this implementation, we check if there is more than one item (>1).
+                    // If so, we treat item 0 as a title and display the skip menu after it.
+                    // This approach allows for flexible UI designs while maintaining essential functionality.
+                    viewdata.itemIdx > 1                                     &&
                     viewdata.itemIdx < viewdata.itemCount - 1) {
 
                     // Show skip screen and enable button handler

--- a/app/ui/view_x.c
+++ b/app/ui/view_x.c
@@ -361,7 +361,7 @@ void h_review_loop_end() {
                 if (viewdata.with_confirmation &&
                     (review_type == REVIEW_TXN || review_type == REVIEW_MSG) &&
                     viewdata.pageIdx == viewdata.pageCount - 1               &&
-                    viewdata.itemIdx > getIntroPages()                       &&
+                    viewdata.itemIdx > getIntroPages() + 1                   &&
                     viewdata.itemIdx < viewdata.itemCount - 1) {
 
                     // Show skip screen and enable button handler

--- a/include/zxversion.h
+++ b/include/zxversion.h
@@ -16,5 +16,5 @@
 #pragma once
 
 #define ZXLIB_MAJOR 30
-#define ZXLIB_MINOR 0
-#define ZXLIB_PATCH 1
+#define ZXLIB_MINOR 1
+#define ZXLIB_PATCH 0

--- a/include/zxversion.h
+++ b/include/zxversion.h
@@ -17,4 +17,4 @@
 
 #define ZXLIB_MAJOR 30
 #define ZXLIB_MINOR 0
-#define ZXLIB_PATCH 0
+#define ZXLIB_PATCH 1


### PR DESCRIPTION
### **Feature: Skip Option During Transaction Review**

**Overview:**
Introduces the ability for users to skip any item during the transaction review process and directly navigate to the approval menu. This feature is implemented by invoking the new `view_review_init_progressive` function:

```c
view_review_init_progressive(tx_getItem, tx_getNumItems, app_sign_eth);
view_review_show(REVIEW_TXN);
```

**User Flow:**
1. **Review Message:**
     - **Item 1**
       - Page 1
       - Page 2
       - Page 3
2. **Continue/Skip Menu:**
   - **Right Button:** Continue to the next item.
   - **Left Button:** Go back to previous item.
   - **Both Buttons:** Skip to the approval menu.
3. **Review Subsequent Items:**
   - **Item 2**
     - Page 1
   - **Continue/Skip Menu**
   - **Item 3**
     - Page 1
     - Page 2
4. **Approval Menu:**
   - Final step to approve and sign the transaction.

**Compatibility:**
- **Supported Targets:** All except STAX and FLEX.
- **Purpose:** Mimics the review flow used in app-ethereum for EIP-191 personal messages.

**Implementation Details:**
- **Custom Callback Handler:** 
  - Created to overcome limitations of the `UX_STEP_CB` macro.
  - Handles right/left and both button presses.
  - Re-initializes the UI stack to support multiple options on the same screen(nanox/nanos+).
  
**Compilation Flag Consideration:**
- **Current Status:** Feature is enabled by default when calling `view_review_init_progressive`.
- **Future Consideration:** Evaluate the need for a compilation flag to toggle this feature as needed.

bellow examples for nanos/nanox/nanosp device:

## Enhanced Explanation of Images for Ethereum Personal Message Navigation:

The images below illustrate the navigation and approval process for reviewing and approving an Ethereum personal message on Ledger devices. Note that the formatting of the message depends on the app and is not influenced by the proposed navigation changes.

### Enhanced Explanation of Images for Ethereum Personal Message Navigation:

The images below illustrate the navigation and approval process for reviewing and approving an Ethereum personal message on Ledger devices. Note that the formatting of the message depends on the app and is not influenced by the proposed navigation changes.

---
### Enhanced Explanation of Images for Ethereum Personal Message Navigation:

The images below illustrate the navigation and approval process for reviewing and approving an Ethereum personal message on Ledger devices. Note that the formatting of the message depends on the app and is not influenced by the proposed navigation changes.

---

### Complete Review Navigation (Normal Flow):

#### Nano S and Nano X:
- **Nano S:**  
  The user navigates through the message review screens using the right button. After reviewing all message pages, the "Skip" menu appears, but the user proceeds past it by pressing the right button until they reach the "Approve" screen, where they confirm the action.

![Nano S Example](https://github.com/user-attachments/assets/d6b5979f-024e-4efa-8914-bb8febd9136a)

- **Nano SP:**  
  Similarly, the Nano SP follows the same navigation flow, where the user reviews all message screens and skips the "Skip" menu by clicking the right button until reaching the "Approve" screen.

![Nano SP Example](https://github.com/user-attachments/assets/9c62b53b-0f55-4a4e-a614-da335fe0c7f4)

---

### Advanced Navigation Examples:

#### Nano S (Backward and Skip Navigation):
- In this case, the user navigates forward until reaching the second "Skip" menu. They then decide to go back to the first "Skip" menu by pressing the left button. At the first "Skip" menu, they press both buttons simultaneously, which skips the remaining items in the navigation flow and jumps directly to the "Approve" screen.

![Nano S Advanced Example](https://github.com/user-attachments/assets/6a293b21-d2dc-4ecc-b31b-c5d9cd6e30b9)

#### Nano X / Nano SP (Simplified Backward Navigation):

- When navigating backward on Nano X and Nano SP devices, the implementation simplifies the process by only displaying the first page of each item in the review. Moving forward displays all pages, including the "Skip" menu.
- The user navigates to the last message screen (`\x92and format`), goes back to see the first pages of previous items, and returns to the initial page. Moving forward again to the "Skip" menu, they press both buttons to skip directly to the "Approve" menu.

![Nano X/SP Advanced Example](https://github.com/user-attachments/assets/79a78751-1b99-4180-a760-2642a8605dc2)


### Summary of Navigation Types:

1. **Normal Navigation (No Skip):**
   - Devices: Nano S, Nano X, Nano SP
   - Users navigate sequentially through all message pages and confirm on the "Approve" screen.

2. **Advanced Navigation (Backward and Skip):**
   - Devices: Nano S
   - Users navigate backward and use the "Skip" menu to jump directly to the "Approve" screen.

3. **Simplified Backward Navigation:**
   - Devices: Nano X, Nano SP
   - Backward navigation displays the first page of items, while forward navigation shows all pages, including the "Skip" menu.


<!-- ClickUpRef: 8696xbgwn -->
:link: [zboto Link](https://app.clickup.com/t/8696xbgwn)