### PR TITLE
Export switch subtext setter

### DIFF
--- a/app/ui/view.h
+++ b/app/ui/view.h
@@ -130,3 +130,21 @@ void view_inspect_init(viewfunc_getInnerItem_t view_funcGetInnerItem, viewfunc_g
 void view_review_show(review_type_e reviewKind);
 
 void view_review_show_generic(review_type_e reviewKind, const char *title, const char *validate);
+
+#if defined(TARGET_STAX) || defined(TARGET_FLEX)
+typedef enum {
+    EXPERT_MODE = 0,
+#ifdef APP_ACCOUNT_MODE_ENABLED
+    ACCOUNT_MODE,
+#endif
+#ifdef APP_SECRET_MODE_ENABLED
+    SECRET_MODE,
+#endif
+#ifdef APP_BLINDSIGN_MODE_ENABLED
+    BLINDSIGN_MODE,
+#endif
+    SETTINGS_SWITCHES_NB_LEN
+} settings_list_e;
+
+void view_set_switch_subtext(settings_list_e switch_id, const char *subtext);
+#endif // TARGET_STAX || TARGET_FLEX

--- a/app/ui/view_nbgl.c
+++ b/app/ui/view_nbgl.c
@@ -271,7 +271,7 @@ static void settings_screen_callback(uint8_t index, nbgl_content_t *content) {
     UNUSED(index);
     switches[EXPERT_MODE].initState = app_mode_expert();
     switches[EXPERT_MODE].text = "Expert mode";
-    switches[EXPERT_MODE].subText = "";
+    switches[EXPERT_MODE].subText = "Enable to review extra fields";
     switches[EXPERT_MODE].tuneId = TUNE_TAP_CASUAL;
     switches[EXPERT_MODE].token = EXPERT_MODE_TOKEN;
 
@@ -279,7 +279,7 @@ static void settings_screen_callback(uint8_t index, nbgl_content_t *content) {
     switches[BLINDSIGN_MODE].initState = app_mode_blindsign();
     switches[BLINDSIGN_MODE].text = "Blind sign";
     if ((switches[BLINDSIGN_MODE].subText) == NULL) {
-        switches[BLINDSIGN_MODE].subText = "Allows signing transactions without seeing all fields";
+        switches[BLINDSIGN_MODE].subText = "Enable to sign transactions without reviewing all fields";
     }
     switches[BLINDSIGN_MODE].tuneId = TUNE_TAP_CASUAL;
     switches[BLINDSIGN_MODE].token = BLINDSIGN_MODE_TOKEN;

--- a/app/ui/view_nbgl.c
+++ b/app/ui/view_nbgl.c
@@ -58,20 +58,6 @@ static nbgl_layoutTagValueList_t pairList;
 static nbgl_layoutTagValueList_t *extraPagesPtr = NULL;
 
 typedef enum {
-    EXPERT_MODE = 0,
-#ifdef APP_ACCOUNT_MODE_ENABLED
-    ACCOUNT_MODE,
-#endif
-#ifdef APP_SECRET_MODE_ENABLED
-    SECRET_MODE,
-#endif
-#ifdef APP_BLINDSIGN_MODE_ENABLED
-    BLINDSIGN_MODE,
-#endif
-    SETTINGS_SWITCHES_NB_LEN
-} settings_list_e;
-
-typedef enum {
     EXPERT_MODE_TOKEN = FIRST_USER_TOKEN,
     ACCOUNT_MODE_TOKEN,
     SECRET_MODE_TOKEN,
@@ -292,7 +278,9 @@ static void settings_screen_callback(uint8_t index, nbgl_content_t *content) {
 #ifdef APP_BLINDSIGN_MODE_ENABLED
     switches[BLINDSIGN_MODE].initState = app_mode_blindsign();
     switches[BLINDSIGN_MODE].text = "Blind sign";
-    switches[BLINDSIGN_MODE].subText = "";
+    if ((switches[BLINDSIGN_MODE].subText) == NULL) {
+        switches[BLINDSIGN_MODE].subText = "Allows signing transactions without seeing all fields";
+    }
     switches[BLINDSIGN_MODE].tuneId = TUNE_TAP_CASUAL;
     switches[BLINDSIGN_MODE].token = BLINDSIGN_MODE_TOKEN;
 #endif
@@ -503,6 +491,13 @@ void view_review_show_impl(unsigned int requireReply, const char *title, const c
             config_useCaseReview(TYPE_TRANSACTION);
             break;
     }
+}
+
+void view_set_switch_subtext(settings_list_e switch_id, const char *subtext) {
+    if (switch_id >= SETTINGS_SWITCHES_NB_LEN) {
+        return;
+    }
+    switches[switch_id].subText = subtext;
 }
 
 #endif

--- a/include/zxversion.h
+++ b/include/zxversion.h
@@ -16,5 +16,5 @@
 #pragma once
 
 #define ZXLIB_MAJOR 30
-#define ZXLIB_MINOR 1
-#define ZXLIB_PATCH 3
+#define ZXLIB_MINOR 2
+#define ZXLIB_PATCH 0


### PR DESCRIPTION
- Created `view_set_switch_subtext` so that any app can modify the subtext of a switch according to its needs.

<!-- ClickUpRef: 869791q45 -->
:link: [zboto Link](https://app.clickup.com/t/869791q45)