### PR TITLE
Fix Bug on setting switch text

### DIFF
--- a/app/ui/view_nbgl.c
+++ b/app/ui/view_nbgl.c
@@ -291,7 +291,7 @@ static void settings_screen_callback(uint8_t index, nbgl_content_t *content) {
     switches[EXPERT_MODE].initState = app_mode_expert();
     switches[EXPERT_MODE].text = "Expert mode";
     if ((switches[EXPERT_MODE].subText) == NULL) {
-        switches[EXPERT_MODE].subText = "Enable to review extra fields";
+        switches[EXPERT_MODE].subText = "Enable expert mode.";
     }
     switches[EXPERT_MODE].tuneId = TUNE_TAP_CASUAL;
     switches[EXPERT_MODE].token = EXPERT_MODE_TOKEN;
@@ -300,7 +300,7 @@ static void settings_screen_callback(uint8_t index, nbgl_content_t *content) {
     switches[BLINDSIGN_MODE].initState = app_mode_blindsign();
     switches[BLINDSIGN_MODE].text = "Blind sign";
     if ((switches[BLINDSIGN_MODE].subText) == NULL) {
-        switches[BLINDSIGN_MODE].subText = "Enable to sign transactions without reviewing all fields";
+        switches[BLINDSIGN_MODE].subText = "Enable transaction blind signing.";
     }
     switches[BLINDSIGN_MODE].tuneId = TUNE_TAP_CASUAL;
     switches[BLINDSIGN_MODE].token = BLINDSIGN_MODE_TOKEN;

--- a/app/ui/view_nbgl.c
+++ b/app/ui/view_nbgl.c
@@ -94,7 +94,7 @@ static void h_blindsign_toggle() { app_mode_set_blindsign(!app_mode_blindsign())
 
 static void confirm_error(__Z_UNUSED bool confirm) { h_error_accept(0); }
 
-static void goto_settings(bool confirm) { 
+static void goto_settings(bool confirm) {
     if (confirm) {
         view_settings_show_impl();
     } else {
@@ -290,7 +290,9 @@ static void settings_screen_callback(uint8_t index, nbgl_content_t *content) {
     UNUSED(index);
     switches[EXPERT_MODE].initState = app_mode_expert();
     switches[EXPERT_MODE].text = "Expert mode";
-    switches[EXPERT_MODE].subText = "Enable to review extra fields";
+    if ((switches[EXPERT_MODE].subText) == NULL) {
+        switches[EXPERT_MODE].subText = "Enable to review extra fields";
+    }
     switches[EXPERT_MODE].tuneId = TUNE_TAP_CASUAL;
     switches[EXPERT_MODE].token = EXPERT_MODE_TOKEN;
 
@@ -308,7 +310,9 @@ static void settings_screen_callback(uint8_t index, nbgl_content_t *content) {
     if (app_mode_expert() || app_mode_account()) {
         switches[ACCOUNT_MODE].initState = app_mode_account();
         switches[ACCOUNT_MODE].text = "Crowdloan account";
-        switches[ACCOUNT_MODE].subText = "";
+        if ((switches[ACCOUNT_MODE].subText) == NULL) {
+            switches[ACCOUNT_MODE].subText = "";
+        }
         switches[ACCOUNT_MODE].tuneId = TUNE_TAP_CASUAL;
         switches[ACCOUNT_MODE].token = ACCOUNT_MODE_TOKEN;
     }
@@ -318,7 +322,9 @@ static void settings_screen_callback(uint8_t index, nbgl_content_t *content) {
     if (app_mode_expert() || app_mode_secret()) {
         switches[SECRET_MODE].initState = app_mode_secret();
         switches[SECRET_MODE].text = "Secret mode";
-        switches[SECRET_MODE].subText = "";
+        if ((switches[SECRET_MODE].subText) == NULL) {
+            switches[SECRET_MODE].subText = "";
+        }
         switches[SECRET_MODE].tuneId = TUNE_TAP_CASUAL;
         switches[SECRET_MODE].token = SECRET_MODE_TOKEN;
     }

--- a/include/zxversion.h
+++ b/include/zxversion.h
@@ -17,4 +17,4 @@
 
 #define ZXLIB_MAJOR 31
 #define ZXLIB_MINOR 1
-#define ZXLIB_PATCH 0
+#define ZXLIB_PATCH 1


### PR DESCRIPTION
If the user of zxlib has called `view_set_switch_subtext`, we check for that on the UI callback.