### PR TITLE
Use only original output directories

### DIFF
--- a/dockerized_build.mk
+++ b/dockerized_build.mk
@@ -23,7 +23,9 @@ TESTS_JS_DIR?=
 LEDGER_SRC=$(CURDIR)/app
 FUZZ_COVERAGE_DIR=$(CURDIR)/fuzz/coverage
 DOCKER_APP_SRC=/app
-DOCKER_APP_BIN=$(DOCKER_APP_SRC)/app/bin/app.elf
+# Note: BIN_DIR is now build/<TARGET>/bin, but this variable is kept for reference
+# The actual path varies by target: build/nanox/bin, build/nanos2/bin, etc.
+DOCKER_APP_BIN=$(DOCKER_APP_SRC)/app/build/$(TARGET)/bin/app.elf
 
 DOCKER_BOLOS_SDKS = NANOS_SDK
 DOCKER_BOLOS_SDKX = NANOX_SDK

--- a/include/zxversion.h
+++ b/include/zxversion.h
@@ -16,5 +16,5 @@
 #pragma once
 
 #define ZXLIB_MAJOR 39
-#define ZXLIB_MINOR 0
+#define ZXLIB_MINOR 1
 #define ZXLIB_PATCH 0

--- a/makefiles/Makefile.installer_script
+++ b/makefiles/Makefile.installer_script
@@ -1,6 +1,6 @@
 #*******************************************************************************
 #  Ledger App
-#  (c) 2018 - 2023 Zondax AG
+#  (c) 2018 - 2024 Zondax AG
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.
@@ -15,6 +15,11 @@
 #  limitations under the License.
 #*******************************************************************************
 
+# BIN_DIR is defined by the SDK in Makefile.target (included via Makefile.standard_app)
+# Path structure: build/<TARGET>/bin (e.g., build/nanox/bin, build/stax/bin)
+# This fallback ensures compatibility if BIN_DIR is not yet defined
+BIN_DIR ?= $(CURDIR)/build/$(TARGET)/bin
+
 all: default
 	@echo "#!/usr/bin/env bash" > $(OUTPUT_INSTALLER)
 	@echo "APPNAME=\"${APPNAME}\"" >> $(OUTPUT_INSTALLER)
@@ -23,10 +28,10 @@ all: default
 	@echo "LOAD_PARAMS=($$(echo "${APP_LOAD_PARAMS}" | sed -e "s|"${APPNAME}"|\""${APPNAME}"\"|"))" >> $(OUTPUT_INSTALLER)
 	@echo "DELETE_PARAMS=($$(echo "${COMMON_DELETE_PARAMS}" | sed -e "s|"${APPNAME}"|\""${APPNAME}"\"|"))" >> $(OUTPUT_INSTALLER)
 	@echo "APPHEX=\"" >> $(OUTPUT_INSTALLER)
-	@cat $(CURDIR)/bin/app.hex >> $(OUTPUT_INSTALLER)
+	@cat $(BIN_DIR)/app.hex >> $(OUTPUT_INSTALLER)
 	@echo "\"" >> $(OUTPUT_INSTALLER)
 	@cat $(CURDIR)/../deps/ledger-zxlib/scripts/template.sh >> $(OUTPUT_INSTALLER)
 	@chmod +x $(OUTPUT_INSTALLER)
-	@cp $(CURDIR)/bin/* $(CURDIR)/output
+	@cp $(BIN_DIR)/* $(CURDIR)/output
 	@cp $(CURDIR)/output/app.elf ${OUTPUT_ELF}
 	@rm $(CURDIR)/output/app.elf


### PR DESCRIPTION
<!-- ClickUpRef: 8699pghcj -->
:link: [zboto Link](https://app.clickup.com/t/8699pghcj)

> 
> As requested by Ledger : 
> We are planning some cleanup in the SDK. Currently, there are 2 directories that are created and populated with app build results. 
> - `app/build`
> - `app/debug`
> Those are only copies from the output build directories (respectively build/<device>/bin/ and build/<device>/dbg/).
> We plan to remove them from the SDK

This PR prepares a cleanup to use directly the output build directories.