### PR TITLE
Fix screen for EVM

### DIFF
--- a/evm/evm_eip191.c
+++ b/evm/evm_eip191.c
@@ -82,7 +82,7 @@ zxerr_t eip191_msg_getItem(int8_t displayIdx, char *outKey, uint16_t outKeyLen, 
 
             // print message
             snprintf(outKey, outKeyLen, "Msg");
-            pageString(outVal, outValLen, (const char *)message, pageIdx, pageCount);
+            pageStringExt(outVal, outValLen, (const char *)message, messageLength, pageIdx, pageCount);
             return zxerr_ok;
         }
         default:

--- a/include/zxversion.h
+++ b/include/zxversion.h
@@ -17,4 +17,4 @@
 
 #define ZXLIB_MAJOR 35
 #define ZXLIB_MINOR 1
-#define ZXLIB_PATCH 0
+#define ZXLIB_PATCH 1


### PR DESCRIPTION
Fixed the length of the message displayed on screen through multiple EVM EIP-191 calls

<!-- ClickUpRef: 8699tqjzu -->
:link: [zboto Link](https://app.clickup.com/t/8699tqjzu)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved message display logic to ensure accurate pagination and handling of message content.

* **Chores**
  * Updated the library patch version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->