### PR TITLE
Remove colon in hash 

### DIFF
--- a/evm/parser_impl_evm.c
+++ b/evm/parser_impl_evm.c
@@ -237,7 +237,7 @@
      char hex[65] = {0};
      array_to_hexstr(hex, 65, hash, 32);
  
-     snprintf(outKey, outKeyLen, "Eth-Hash:");
+     snprintf(outKey, outKeyLen, "Eth-Hash");
  
      pageString(outVal, outValLen, hex, pageIdx, pageCount);
  

--- a/include/zxversion.h
+++ b/include/zxversion.h
@@ -17,4 +17,4 @@
 
 #define ZXLIB_MAJOR 35
 #define ZXLIB_MINOR 1
-#define ZXLIB_PATCH 3
+#define ZXLIB_PATCH 4


### PR DESCRIPTION
<!-- ClickUpRef: 8699wpc4e -->
:link: [zboto Link](https://app.clickup.com/t/8699wpc4e)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the formatting of the "Eth-Hash" output by removing the trailing colon.
* **Chores**
  * Incremented the patch version number to 4.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->