### PR TITLE
Adds review with intent functionality

### DIFF
--- a/app/ui/view.c
+++ b/app/ui/view.c
@@ -78,6 +78,11 @@ void view_review_show(review_type_e reviewKind) {
     view_review_show_impl((unsigned int)reviewKind, NULL, NULL);
 }
 
+void view_review_show_with_intent(review_type_e reviewKind, const char *intent) {
+    // New function that explicitly handles intent
+    view_review_show_with_intent_impl((unsigned int)reviewKind, intent);
+}
+
 void view_review_show_generic(review_type_e reviewKind, const char *title, const char *validate) {
     view_review_show_impl((unsigned int)reviewKind, title, validate);
 }

--- a/app/ui/view.h
+++ b/app/ui/view.h
@@ -128,6 +128,8 @@ void view_inspect_init(viewfunc_getInnerItem_t view_funcGetInnerItem, viewfunc_g
 
 void view_review_show(review_type_e reviewKind);
 
+void view_review_show_with_intent(review_type_e reviewKind, const char *intent);
+
 void view_spinner_show(const char *text);
 
 void view_review_show_generic(review_type_e reviewKind, const char *title, const char *validate);

--- a/app/ui/view_internal.h
+++ b/app/ui/view_internal.h
@@ -230,6 +230,8 @@ void h_inspect_init();
 
 void view_review_show_impl(unsigned int requireReply, const char *title, const char *validate);
 
+void view_review_show_with_intent_impl(unsigned int requireReply, const char *intent);
+
 void view_inspect_show_impl();
 
 void view_initialize_show_impl(uint8_t item_idx, const char *statusString);

--- a/app/ui/view_nbgl.c
+++ b/app/ui/view_nbgl.c
@@ -582,7 +582,7 @@ void view_review_show_with_intent_impl(unsigned int requireReply, const char *in
         // Show everything on a single line for NBGL
         const char *review_text = (review_type == REVIEW_MSG) ? "Review message" : "Review transaction";
         int ret = snprintf(intro_msg_buf, sizeof(intro_msg_buf), "%s to %s", review_text, intent);
-        
+
         // Check if truncation occurred and add ellipsis if needed
         if (ret >= (int)sizeof(intro_msg_buf)) {
             const size_t buf_len = sizeof(intro_msg_buf);

--- a/app/ui/view_s.c
+++ b/app/ui/view_s.c
@@ -608,4 +608,11 @@ static unsigned int view_skip_button(unsigned int button_mask, __Z_UNUSED unsign
     return 0;
 }
 
+void view_review_show_with_intent_impl(unsigned int requireReply, const char *intent) {
+    // For Nano S, we don't have space to display the intent in the title
+    // Just use the normal review flow
+    UNUSED(intent);
+    view_review_show_impl(requireReply, NULL, NULL);
+}
+
 #endif

--- a/app/ui/view_x.c
+++ b/app/ui/view_x.c
@@ -282,7 +282,6 @@ UX_FLOW_DEF_NOCB(ux_review_flow_4_review_title, pbb,
                      REVIEW_MSG_TITLE,
                      REVIEW_MSG_VALUE,
                  });
-
 UX_STEP_INIT(ux_review_flow_2_start_step, NULL, NULL, { h_review_loop_start(); });
 #ifdef HAVE_INSPECT
 UX_STEP_CB_INIT(ux_review_flow_2_step, bnnn_paging, h_review_loop_inside(), inspect_init(),
@@ -565,6 +564,77 @@ void view_review_show_impl(unsigned int requireReply, const char *title, const c
 }
 
 void run_root_txn_flow() { run_ux_review_flow(review_type, &ux_review_flow_2_start_step); }
+
+void view_review_show_with_intent_impl(unsigned int requireReply, const char *intent) {
+    review_type = requireReply;
+    h_paging_init();
+    h_paging_decrease();
+
+    // Format the intro message based on the intent
+    if (intent != NULL && strlen(intent) > 0) {
+        // Put "Review transaction" or "Review message" on first line
+        const char *first_line = (review_type == REVIEW_MSG) ? "Review message" : "Review transaction";
+        snprintf(intro_msg_buf, sizeof(intro_msg_buf), "%s", first_line);
+        
+        // Put "to {intent}" on second line
+        const size_t max_intent_len = sizeof(intro_submsg_buf) - 4; // "to " + null terminator
+        int ret = snprintf(intro_submsg_buf, sizeof(intro_submsg_buf), "to %.*s", 
+                          (int)max_intent_len, intent);
+        
+        // Check if truncation occurred and add ellipsis if needed
+        if (ret >= (int)sizeof(intro_submsg_buf)) {
+            const size_t buf_len = sizeof(intro_submsg_buf);
+            if (buf_len >= 4) {
+                intro_submsg_buf[buf_len - 4] = '.';
+                intro_submsg_buf[buf_len - 3] = '.';
+                intro_submsg_buf[buf_len - 2] = '.';
+                intro_submsg_buf[buf_len - 1] = '\0';
+            }
+        }
+
+        // Use the dynamic review flow for transactions and messages with intent
+        if (review_type == REVIEW_TXN) {
+            flow_inside_loop = 0;
+            if (G_ux.stack_count == 0) {
+                ux_stack_push();
+            }
+            // Build flow with dynamic title for transaction
+            uint8_t index = 0;
+            ux_review_flow[index++] = &ux_review_flow_1_review_group_title;
+            ux_review_flow[index++] = &ux_review_flow_2_start_step;
+            ux_review_flow[index++] = &ux_review_flow_2_step;
+            ux_review_flow[index++] = &ux_review_flow_2_end_step;
+            ux_review_flow[index++] = &ux_review_flow_3_step;
+            ux_review_flow[index++] = FLOW_END_STEP;
+            ux_flow_init(0, ux_review_flow, NULL);
+            return;
+        } else if (review_type == REVIEW_MSG) {
+            // Create custom flow for message with intent
+            flow_inside_loop = 0;
+            if (G_ux.stack_count == 0) {
+                ux_stack_push();
+            }
+            // Build flow with dynamic title for message
+            uint8_t index = 0;
+            // Use the group title flow which displays intro_msg_buf
+            ux_review_flow[index++] = &ux_review_flow_1_review_group_title;
+            ux_review_flow[index++] = &ux_review_flow_2_start_step;
+            ux_review_flow[index++] = &ux_review_flow_2_step;
+            ux_review_flow[index++] = &ux_review_flow_2_end_step;
+            ux_review_flow[index++] = &ux_review_flow_6_step;
+            ux_review_flow[index++] = FLOW_END_STEP;
+            ux_flow_init(0, ux_review_flow, NULL);
+            return;
+        }
+    }
+
+    // Fallback to normal review flow if no intent or other review types
+    flow_inside_loop = 0;
+    if (G_ux.stack_count == 0) {
+        ux_stack_push();
+    }
+    run_ux_review_flow((review_type_e)review_type, NULL);
+}
 
 // Build review UX flow and run it
 void run_ux_review_flow(review_type_e reviewType, const ux_flow_step_t *const start_step) {

--- a/app/ui/view_x.c
+++ b/app/ui/view_x.c
@@ -577,7 +577,7 @@ void view_review_show_with_intent_impl(unsigned int requireReply, const char *in
         snprintf(intro_msg_buf, sizeof(intro_msg_buf), "%s", first_line);
 
         // Put "to {intent}" on second line
-        const size_t max_intent_len = sizeof(intro_submsg_buf) - 4;  // "to " + null terminator
+        const size_t max_intent_len = sizeof(intro_submsg_buf) - 4;  // Reserve 4 bytes: "to " (3) + null terminator (1)
         int ret = snprintf(intro_submsg_buf, sizeof(intro_submsg_buf), "to %.*s", (int)max_intent_len, intent);
 
         // Check if truncation occurred and add ellipsis if needed

--- a/app/ui/view_x.c
+++ b/app/ui/view_x.c
@@ -575,12 +575,11 @@ void view_review_show_with_intent_impl(unsigned int requireReply, const char *in
         // Put "Review transaction" or "Review message" on first line
         const char *first_line = (review_type == REVIEW_MSG) ? "Review message" : "Review transaction";
         snprintf(intro_msg_buf, sizeof(intro_msg_buf), "%s", first_line);
-        
+
         // Put "to {intent}" on second line
-        const size_t max_intent_len = sizeof(intro_submsg_buf) - 4; // "to " + null terminator
-        int ret = snprintf(intro_submsg_buf, sizeof(intro_submsg_buf), "to %.*s", 
-                          (int)max_intent_len, intent);
-        
+        const size_t max_intent_len = sizeof(intro_submsg_buf) - 4;  // "to " + null terminator
+        int ret = snprintf(intro_submsg_buf, sizeof(intro_submsg_buf), "to %.*s", (int)max_intent_len, intent);
+
         // Check if truncation occurred and add ellipsis if needed
         if (ret >= (int)sizeof(intro_submsg_buf)) {
             const size_t buf_len = sizeof(intro_submsg_buf);

--- a/include/zxversion.h
+++ b/include/zxversion.h
@@ -17,4 +17,4 @@
 
 #define ZXLIB_MAJOR 36
 #define ZXLIB_MINOR 0
-#define ZXLIB_PATCH 1
+#define ZXLIB_PATCH 2


### PR DESCRIPTION
Introduces a new function to display review screens with an intent string. This allows to present the
user with context regarding the review, such as
"Review transaction to [recipient]".

This change supports various device layouts, including Nano S, Nano X, and Stax/Flex, adapting the display based on available screen space.

<!-- ClickUpRef: 869a2p04e -->
:link: [zboto Link](https://app.clickup.com/t/869a2p04e)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for displaying review screens with a custom intent message, enhancing clarity when reviewing messages or transactions.
* **Style**
  * Improved layout separation in the review configuration for better readability.
* **Chores**
  * Updated the patch version number to reflect recent changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->