### PR TITLE
Chain ID must not be 0 or 1

### DIFF
--- a/evm/parser_impl_evm.c
+++ b/evm/parser_impl_evm.c
@@ -42,6 +42,8 @@ eth_tx_t eth_tx_obj;
 
 #define ETHEREUM_RECOVERY_OFFSET 27
 #define EIP155_V_BASE 35
+#define INVALID_CHAIN_ID_0 0
+#define INVALID_CHAIN_ID_1 1
 
 static parser_error_t readChainID(parser_context_t *ctx, rlp_t *chainId) {
     if (ctx == NULL || chainId == NULL) {
@@ -57,6 +59,12 @@ static parser_error_t readChainID(parser_context_t *ctx, rlp_t *chainId) {
         tmpChainId = chainId->ptr[0];
     } else {
         return parser_unexpected_error;
+    }
+
+    // According to Ledger's specifications, chain ID must not be 0 or 1
+    // when using an Ethereum derivation path
+    if (tmpChainId == INVALID_CHAIN_ID_0 || tmpChainId == INVALID_CHAIN_ID_1) {
+        return parser_invalid_chain_id;
     }
 
     if (supported_networks_evm_len == 0) {

--- a/include/zxversion.h
+++ b/include/zxversion.h
@@ -17,4 +17,4 @@
 
 #define ZXLIB_MAJOR 36
 #define ZXLIB_MINOR 0
-#define ZXLIB_PATCH 4
+#define ZXLIB_PATCH 5


### PR DESCRIPTION
<!-- ClickUpRef: 869a4f3pe -->
:link: [zboto Link](https://app.clickup.com/t/869a4f3pe)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Strengthened EVM network validation: only connects to configured supported networks; rejects chain IDs 0 and 1 with clear errors.

- Bug Fixes
  - Prevented accidental use of unsupported or invalid EVM chain IDs, reducing connection and decoding failures.

- Chores
  - Increased library patch version to reflect the update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->