### PR TITLE
fix(nbgl): prevent silent truncation of long values on narrow touch screens

### DIFF
--- a/app/ui/view_internal.h
+++ b/app/ui/view_internal.h
@@ -38,8 +38,16 @@
 #include "nbgl_use_case.h"
 #define MAX_LINES_PER_PAGE_REVIEW NB_MAX_LINES_IN_REVIEW
 #define MAX_CHARS_PER_KEY_LINE 64
-#define MAX_CHARS_PER_VALUE1_LINE 180
-#define MAX_CHARS_SUBMSG_LINE 180
+// A review page renders at most NB_MAX_LINES_IN_REVIEW (9) lines for a value.
+// NBGL truncates anything beyond that with "..." and the overflow is never
+// shown: the next page resumes at the next pre-paginated chunk, not where the
+// text was cut. Each value chunk must therefore fit within 9 lines. The
+// narrowest touch screen (Apex) fits ~16 hex chars/line, i.e. 9*16 = 144
+// chars. The previous value of 180 was sized for the wider Stax/Flex screens
+// and overflowed on Apex (and partially on Stax/Flex), silently hiding bytes
+// of long values (e.g. EVM call params) from the signer.
+#define MAX_CHARS_PER_VALUE1_LINE 144
+#define MAX_CHARS_SUBMSG_LINE 144
 #define MAX_CHARS_HEXMESSAGE 160
 #else
 #ifndef MAX_CHARS_PER_VALUE_LINE

--- a/include/zxversion.h
+++ b/include/zxversion.h
@@ -17,4 +17,4 @@
 
 #define ZXLIB_MAJOR 45
 #define ZXLIB_MINOR 0
-#define ZXLIB_PATCH 1
+#define ZXLIB_PATCH 2


### PR DESCRIPTION
## What

For touch targets (Stax / Flex / Apex), lower the per-page value budget from **180 → 144** characters:

```c
#define MAX_CHARS_PER_VALUE1_LINE 144   // was 180
#define MAX_CHARS_SUBMSG_LINE     144   // was 180
```

## Why

Apps pre-paginate long values into chunks of `MAX_CHARS_PER_VALUE1_LINE - 1` characters and hand one chunk per review page to NBGL. NBGL caps the value area of a review page at `NB_MAX_LINES_IN_REVIEW` lines; when a chunk needs more lines than that, NBGL **does not** wrap it to a new page — it draws `"..."` on the last allowed line and discards everything after it. Because the next review page resumes at the *next* pre-paginated chunk (not where the text was visually cut), the dropped characters are **never shown on any page**.

The `180` budget was introduced with Flex support and sized for the wider Stax/Flex screens, where a 179-char chunk fits in ~9 lines. The narrower **Apex** screen fits only ~16 hex chars/line, so the same 179-char chunk needs ~11 lines — and ~2 lines of data are silently dropped.

This is not theoretical. On `app-filecoin`, the `issue-166` transaction (an `InvokeEVM` call with a 455-byte params blob) lost the inner EVM selector `0x43aeeeb2` on Apex: it fell into the truncated region of one page, and the following page resumed past it. The signer never saw it — i.e. **unintended partial blind signing**. Stax/Flex truncate the same chunks too, just less (their wider lines happened to clip only trailing zeros for this particular blob).

### About the `NB_MAX_LINES_IN_REVIEW` cap

The relevant detail is that this cap is **a single, SDK-wide constant** — not per-device:

```c
// ledger-secure-sdk/lib_nbgl/include/nbgl_use_case.h:52
#define NB_MAX_LINES_IN_REVIEW 9        // one definition, no #ifdef, all targets
```

Notably, the *details* ("More") view cap right above it **is** per-device, which shows the SDK differentiates when it intends to:

```c
// nbgl_use_case.h:43-47
#ifdef TARGET_STAX
#define NB_MAX_LINES_IN_DETAILS 12
#else
#define NB_MAX_LINES_IN_DETAILS 11
#endif
```

So every touch device shares the same **line** cap (9), but "9 lines" holds a different number of **characters** depending on screen width (~150 on Apex vs ~180 on Stax/Flex). Since the SDK won't scale the cap per device, the safe fix is to size the per-page character budget so a chunk always fits in 9 lines on the **narrowest** screen.

### The truncation path (for reference)

1. `nbgl_layout.c` clamps the value to the cap: `if (nbMaxLinesForValue > 0 && nbLines > nbMaxLinesForValue) { nbLines = nbMaxLinesForValue; valueTextArea->nbMaxLines = nbMaxLinesForValue; }`
2. `nbgl_obj.c` draws the last allowed line as `lineLen - 3` chars + `"..."` and `return`s, abandoning the rest.

## The fix

`9 lines × ~16 chars/line = 144`. With a 144-char buffer (143 usable chars/page), every chunk fits within 9 lines on the narrowest touch screen, so the clamp never fires, no `"..."` truncation occurs, and the full value is paginated across review pages instead of being dropped.

- **Nano (S+/X)** targets are unaffected — they use a separate define branch (`4096`).
- Long values now span **one extra review page** on touch devices (e.g. a 910-char hex value goes from 6 to 7 pages). This is cosmetic; correctness over page count.
- The value is conservative (9 × 16). Stax/Flex could technically fit a bit more per page, but a single safe-for-narrowest value keeps the code simple and correct everywhere.

### Why a single value instead of per-device

I measured the actual review-value line width on each device by wrapping the known value at candidate widths and matching it against the rendered snapshots:

| Device | hex chars / line |
|--------|------------------|
| Apex   | ~17 |
| Stax   | ~17 (wider screen, but larger font → same as Apex) |
| Flex   | ~18 |

So **Stax and Apex render the same number of characters per line** — there are effectively only two widths, and only Flex is slightly wider. A per-device split (`153 / 153 / 162`) would therefore save at most ~1 page, and only on Flex, for very long values.

It's not worth it: the per-device gain is small, and a single conservative value (a) keeps a ~1 char/line safety margin against font/letter-width variation, and (b) avoids depending on the exact per-device line *count*, which can't be confirmed from this pinned SDK (each device builds against its own SDK, and the taller Stax/Flex screens may allow ~10 review lines rather than 9). One safe value for the whole touch group plays it safe and stays correct everywhere.

## Verification

Built `app-filecoin` for Apex and regenerated the `issue-166` Zemu snapshots:

- `Params |4|` now spans **7 pages** instead of 6.
- The selector `0x43aeeeb2` is now **fully rendered** (page 3/7) instead of hidden.
- **No `"..."`** appears on any page; the 7 pages concatenate to the complete 910-char value with no gaps.
