### PR TITLE
bump container and version; size review value budget per device

### DIFF
--- a/app/ui/view_internal.h
+++ b/app/ui/view_internal.h
@@ -38,17 +38,31 @@
 #include "nbgl_use_case.h"
 #define MAX_LINES_PER_PAGE_REVIEW NB_MAX_LINES_IN_REVIEW
 #define MAX_CHARS_PER_KEY_LINE 64
-// A review page renders at most NB_MAX_LINES_IN_REVIEW (9) lines for a value.
+#define MAX_CHARS_HEXMESSAGE 160
+// A review page renders a value across at most NB_MAX_LINES_IN_REVIEW lines.
 // NBGL truncates anything beyond that with "..." and the overflow is never
 // shown: the next page resumes at the next pre-paginated chunk, not where the
-// text was cut. Each value chunk must therefore fit within 9 lines. The
-// narrowest touch screen (Apex) fits ~16 hex chars/line, i.e. 9*16 = 144
-// chars. The previous value of 180 was sized for the wider Stax/Flex screens
-// and overflowed on Apex (and partially on Stax/Flex), silently hiding bytes
-// of long values (e.g. EVM call params) from the signer.
+// text was cut. So each value chunk (MAX_CHARS_PER_VALUE1_LINE) must fit within
+// that line budget. Sizing it per device = (max review lines) * (hex chars per
+// line); hex digits render at a fixed (tabular) width, so chars/line is
+// constant for the worst-case hex value:
+//   - Stax : 10 lines * 16 chars/line = 160  (NB_MAX_LINES_IN_REVIEW = 10)
+//   - Flex :  9 lines * 18 chars/line = 162  (NB_MAX_LINES_IN_REVIEW =  9)
+//   - Apex :  9 lines * 16 chars/line = 144  (narrowest screen)
+// A flat 144 (sized for the narrowest, Apex) under-fills the taller Stax and
+// wider Flex screens by one line each, needlessly splitting long values (e.g.
+// EVM call params) across extra pages. Sizing per device shows more per page
+// without ever silently hiding bytes from the signer.
+#if defined(TARGET_STAX)
+#define MAX_CHARS_PER_VALUE1_LINE 160
+#define MAX_CHARS_SUBMSG_LINE 160
+#elif defined(TARGET_FLEX)
+#define MAX_CHARS_PER_VALUE1_LINE 162
+#define MAX_CHARS_SUBMSG_LINE 162
+#else  // TARGET_APEX_P
 #define MAX_CHARS_PER_VALUE1_LINE 144
 #define MAX_CHARS_SUBMSG_LINE 144
-#define MAX_CHARS_HEXMESSAGE 160
+#endif
 #else
 #ifndef MAX_CHARS_PER_VALUE_LINE
 #define MAX_CHARS_PER_VALUE_LINE (17)

--- a/dockerized_build.mk
+++ b/dockerized_build.mk
@@ -63,7 +63,7 @@ $(info TESTS_ZEMU_DIR        : $(TESTS_ZEMU_DIR))
 $(info TESTS_JS_DIR          : $(TESTS_JS_DIR))
 $(info TESTS_JS_PACKAGE      : $(TESTS_JS_PACKAGE))
 
-DOCKER_IMAGE_ZONDAX=zondax/ledger-app-builder:ledger-87bd177c426072a2a66a383c286cf2abcb03b5f2
+DOCKER_IMAGE_ZONDAX=zondax/ledger-app-builder:ledger-d84a6cd678ea734626d48f20801e38a9afb690a7
 DOCKER_IMAGE_LEDGER=ghcr.io/ledgerhq/ledger-app-builder/ledger-app-builder:latest
 
 ifdef INTERACTIVE

--- a/include/zxversion.h
+++ b/include/zxversion.h
@@ -15,6 +15,6 @@
  ********************************************************************************/
 #pragma once
 
-#define ZXLIB_MAJOR 45
+#define ZXLIB_MAJOR 46
 #define ZXLIB_MINOR 0
-#define ZXLIB_PATCH 2
+#define ZXLIB_PATCH 0


### PR DESCRIPTION
## Container + version bump
Bumps the Zondax ledger-app-builder image to pick up the new Ledger SDK, triggered by the Ledger Update Bot (app-builder updated: d84a6cd).

- `dockerized_build.mk`: ledger-app-builder → `ledger-d84a6cd678ea734626d48f20801e38a9afb690a7`
- `include/zxversion.h`: `ZXLIB_MAJOR` 45 → 46 (v46.0.0)

## Per-device review value budget (follow-up to #223)
#223 fixed silent truncation of long values by capping `MAX_CHARS_PER_VALUE1_LINE` at 144 for **all** touch devices — sized for the narrowest screen (Apex: 9 lines × 16 hex chars/line). Review feedback on app-filecoin (LedgerHQ/app-filecoin#42, linked #41) noted this is not optimized for the larger screens.

`NB_MAX_LINES_IN_REVIEW` is per device (Stax 10, Flex 9, Apex 9) and Flex fits 18 hex chars/line, so a flat 144 under-fills Stax and Flex by one line each, needlessly splitting long values across extra pages. Now sized per device = (max review lines) × (hex chars/line):

| Device | Lines | Chars/line | Budget |
|--------|-------|-----------|--------|
| Stax | 10 | 16 | **160** |
| Flex | 9 | 18 | **162** |
| Apex | 9 | 16 | 144 |

Shows more of a long value per page without ever silently hiding bytes from the signer. Values measured from the `issue-166` review snapshots (hex digits render at fixed/tabular width, so chars/line is constant).
